### PR TITLE
Fixed the common-langs NPE of Java Version

### DIFF
--- a/servicecomb-server/pom.xml
+++ b/servicecomb-server/pom.xml
@@ -45,6 +45,12 @@
 			<artifactId>transport-rest-vertx</artifactId>
 			<version>${servicecomb.version}</version>
 		</dependency>
+		<!-- Upgrade the commons-lang3 version to support JDK9 and JDK10 -->
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.7</version>
+		</dependency>
 
 		<dependency>
 			<groupId>junit</groupId>
@@ -118,6 +124,7 @@
 							<transformers>
 								<transformer
 									implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+									<!-- I don't think we need this file -->
 									<resource>META-INF/services/com.weibo.api.motan.codec.Serialization</resource>
 								</transformer>
 							</transformers>


### PR DESCRIPTION
To fix the NPE of commons.lang3.

Caused by: java.lang.NullPointerException
	at org.apache.commons.lang3.SystemUtils.isJavaVersionAtLeast(SystemUtils.java:1388)
	at org.apache.commons.lang3.ClassUtils.isAssignable(ClassUtils.java:594)
	at org.apache.commons.lang3.reflect.TypeUtils.isAssignable(TypeUtils.java:375)
	at org.apache.commons.lang3.reflect.TypeUtils.isAssignable(TypeUtils.java:326)
	at org.apache.commons.lang3.reflect.TypeUtils.isAssignable(TypeUtils.java:311)
	at org.apache.servicecomb.swagger.invocation.converter.ConverterMgr.findAssignable(ConverterMgr.java:143)
