### PR TITLE
fix log issue for ServiceComb

### DIFF
--- a/servicecomb-server/pom.xml
+++ b/servicecomb-server/pom.xml
@@ -20,11 +20,29 @@
 		<version.commons-lang3>3.7</version.commons-lang3>
 	</properties>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.apache.servicecomb</groupId>
+				<artifactId>java-chassis-dependencies</artifactId>
+				<version>${servicecomb.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>benchmark.rpc</groupId>
 			<artifactId>benchmark-base</artifactId>
 			<version>${version.benchmark-base}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>ch.qos.logback</groupId>
+					<artifactId>logback-classic</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.servicecomb</groupId>
@@ -41,6 +59,11 @@
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
 			<version>${version.commons-lang3}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-log4j12</artifactId>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Signed-off-by: zhengyangyong <yangyong.zheng@huawei.com>

ServiceComb use log4j as default log implement, we need exclude logback-classic in benchmark-base, or change ServiceComb to use logback.

more info can be found 
http://servicecomb.incubator.apache.org/users/application-boot-process/
http://servicecomb.incubator.apache.org/cn/faqs/     (Q: ServiceComb日志替换)