### PR TITLE
update dubbo to latest version

### DIFF
--- a/dubbo-client/pom.xml
+++ b/dubbo-client/pom.xml
@@ -15,7 +15,7 @@
 		<maven.compiler.target>1.9</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<version.benchmark-base>round-4</version.benchmark-base>
-		<version.dubbo>2.6.0</version.dubbo>
+		<version.dubbo>2.7.0</version.dubbo>
 	</properties>
 
 	<dependencies>
@@ -25,7 +25,7 @@
 			<version>${version.benchmark-base}</version>
 		</dependency>
 		<dependency>
-			<groupId>com.alibaba</groupId>
+			<groupId>org.apache.dubbo</groupId>
 			<artifactId>dubbo</artifactId>
 			<version>${version.dubbo}</version>
 		</dependency>

--- a/dubbo-client/src/main/java/benchmark/rpc/Client.java
+++ b/dubbo-client/src/main/java/benchmark/rpc/Client.java
@@ -16,8 +16,6 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.TimeValue;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-import com.alibaba.dubbo.config.ProtocolConfig;
-
 import benchmark.bean.Page;
 import benchmark.bean.User;
 import benchmark.service.UserService;
@@ -43,7 +41,6 @@ public class Client extends AbstractClient {
 	@TearDown
 	public void close() throws IOException {
 		context.close();
-		ProtocolConfig.destroyAll();
 	}
 
 	@Benchmark

--- a/dubbo-kryo-client/pom.xml
+++ b/dubbo-kryo-client/pom.xml
@@ -15,8 +15,7 @@
 		<maven.compiler.target>1.9</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<version.benchmark-base>round-4</version.benchmark-base>
-		<version.dubbo>2.6.0</version.dubbo>
-		<version.javakaffee>0.42</version.javakaffee>
+		<version.dubbo>2.7.0</version.dubbo>
 	</properties>
 
 	<dependencies>
@@ -26,14 +25,14 @@
 			<version>${version.benchmark-base}</version>
 		</dependency>
 		<dependency>
-			<groupId>com.alibaba</groupId>
+			<groupId>org.apache.dubbo</groupId>
 			<artifactId>dubbo</artifactId>
 			<version>${version.dubbo}</version>
 		</dependency>
 		<dependency>
-			<groupId>de.javakaffee</groupId>
-			<artifactId>kryo-serializers</artifactId>
-			<version>${version.javakaffee}</version>
+			<groupId>org.apache.dubbo</groupId>
+			<artifactId>dubbo-serialization-kryo</artifactId>
+			<version>${version.dubbo}</version>
 		</dependency>
 
 		<dependency>

--- a/dubbo-kryo-client/src/main/java/benchmark/rpc/Client.java
+++ b/dubbo-kryo-client/src/main/java/benchmark/rpc/Client.java
@@ -16,8 +16,6 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.TimeValue;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-import com.alibaba.dubbo.config.ProtocolConfig;
-
 import benchmark.bean.Page;
 import benchmark.bean.User;
 import benchmark.service.UserService;
@@ -43,7 +41,6 @@ public class Client extends AbstractClient {
 	@TearDown
 	public void close() throws IOException {
 		context.close();
-		ProtocolConfig.destroyAll();
 	}
 
 	@Benchmark

--- a/dubbo-kryo-client/src/main/resources/consumer.xml
+++ b/dubbo-kryo-client/src/main/resources/consumer.xml
@@ -8,7 +8,7 @@
 
 	<!-- 生成远程服务代理，可以和本地bean一样使用demoService -->
 	<dubbo:reference id="userService" check="false"
-		interface="benchmark.service.UserService" url="dubbo://benchmark-server:8080?serialization=kryo" />
+		interface="benchmark.service.UserService" url="dubbo://benchmark-server:8080" />
 
 	<!-- dubbo://benchmark-rpc:8080?serialization=kryo -->
 

--- a/dubbo-kryo-server/pom.xml
+++ b/dubbo-kryo-server/pom.xml
@@ -15,8 +15,7 @@
 		<maven.compiler.target>1.9</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<version.benchmark-base>round-4</version.benchmark-base>
-		<version.dubbo>2.6.0</version.dubbo>
-		<version.javakaffee>0.42</version.javakaffee>
+		<version.dubbo>2.7.0</version.dubbo>
 	</properties>
 
 	<dependencies>
@@ -26,14 +25,14 @@
 			<version>${version.benchmark-base}</version>
 		</dependency>
 		<dependency>
-			<groupId>com.alibaba</groupId>
+			<groupId>org.apache.dubbo</groupId>
 			<artifactId>dubbo</artifactId>
 			<version>${version.dubbo}</version>
 		</dependency>
 		<dependency>
-			<groupId>de.javakaffee</groupId>
-			<artifactId>kryo-serializers</artifactId>
-			<version>${version.javakaffee}</version>
+			<groupId>org.apache.dubbo</groupId>
+			<artifactId>dubbo-serialization-kryo</artifactId>
+			<version>${version.dubbo}</version>
 		</dependency>
 
 		<dependency>

--- a/dubbo-server/pom.xml
+++ b/dubbo-server/pom.xml
@@ -15,7 +15,7 @@
 		<maven.compiler.target>1.9</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<version.benchmark-base>round-4</version.benchmark-base>
-		<version.dubbo>2.6.0</version.dubbo>
+		<version.dubbo>2.7.0</version.dubbo>
 	</properties>
 
 	<dependencies>
@@ -25,7 +25,7 @@
 			<version>${version.benchmark-base}</version>
 		</dependency>
 		<dependency>
-			<groupId>com.alibaba</groupId>
+			<groupId>org.apache.dubbo</groupId>
 			<artifactId>dubbo</artifactId>
 			<version>${version.dubbo}</version>
 		</dependency>


### PR DESCRIPTION
Upgrade to dubbo version 2.7.0

Group name is changed to `org.apache.dubbo`