### PR TITLE
udpate grpc setting

### DIFF
--- a/grpc-client/src/main/java/benchmark/rpc/grpc/UserServiceGrpcClientImpl.java
+++ b/grpc-client/src/main/java/benchmark/rpc/grpc/UserServiceGrpcClientImpl.java
@@ -1,14 +1,5 @@
 package benchmark.rpc.grpc;
 
-import java.io.Closeable;
-import java.io.IOException;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
 import benchmark.bean.Page;
 import benchmark.bean.User;
 import benchmark.rpc.grpc.UserServiceOuterClass.CreateUserResponse;
@@ -21,115 +12,166 @@ import benchmark.service.UserService;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 
+import java.io.Closeable;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
 public class UserServiceGrpcClientImpl implements UserService, Closeable {
 
-	private final String host = "benchmark-server";
-	private final int port = 8080;
+    private final String host = "benchmark-server";
+    private final int port = 8080;
 
-	private final ManagedChannel channel;
-	private final UserServiceGrpc.UserServiceBlockingStub userServiceBlockingStub;
+    private final List<ManagedChannel> channels = new ArrayList<>();
+    private final List<UserServiceGrpc.UserServiceFutureStub> userServiceFutureStubs = new ArrayList<>();
+    private final int channelCount = 6;
+    // care thread safe?
+    private int currentIndex = 0;
 
-	public UserServiceGrpcClientImpl() {
-		ManagedChannelBuilder<?> channelBuilder = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true);
-		channel = channelBuilder.build();
-		userServiceBlockingStub = UserServiceGrpc.newBlockingStub(channel);
-	}
+    public UserServiceGrpcClientImpl() {
+        for (int i = 0; i < channelCount; i++) {
+            ManagedChannelBuilder<?> channelBuilder = ManagedChannelBuilder
+                    .forAddress(host, port)
+                    .directExecutor()
+                    .usePlaintext();
+            ManagedChannel channel = channelBuilder.build();
+            channels.add(channel);
+            userServiceFutureStubs.add(UserServiceGrpc.newFutureStub(channel));
+        }
+    }
 
-	@Override
-	public void close() throws IOException {
-		try {
-			channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
-		} catch (InterruptedException e) {
-			e.printStackTrace();
-		}
-	}
+    @Override
+    public void close() throws IOException {
+        channels.forEach(channel -> {
+            try {
+                channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        });
+    }
 
-	@Override
-	public boolean existUser(String email) {
-		UserExistRequest request = UserExistRequest.newBuilder().setEmail(email).build();
-		UserExistResponse response = userServiceBlockingStub.userExist(request);
+    private UserServiceGrpc.UserServiceFutureStub userServiceFutureStub() {
+        int index = (currentIndex + 1) % channelCount;
+        currentIndex = index;
+        return userServiceFutureStubs.get(index);
+    }
 
-		return response.getExist();
-	}
+    @Override
+    public boolean existUser(String email) {
+        UserExistRequest request = UserExistRequest.newBuilder().setEmail(email).build();
+        UserExistResponse response = null;
+        try {
+            response = userServiceFutureStub().userExist(request).get();
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
 
-	@Override
-	public boolean createUser(User user) {
-		benchmark.rpc.grpc.UserServiceOuterClass.User request = benchmark.rpc.grpc.UserServiceOuterClass.User
-				.newBuilder()//
-				.setId(user.getId())//
-				.setName(user.getName())//
-				.setSex(user.getSex())//
-				.setBirthday((int) (user.getBirthday().toEpochDay()))//
-				.setEmail(user.getEmail())//
-				.setMobile(user.getMobile())//
-				.setAddress(user.getAddress())//
-				.setIcon(user.getIcon())//
-				.addAllPermissions(user.getPermissions())//
-				.setStatus(user.getStatus())//
-				.setCreateTime(user.getCreateTime().toEpochSecond(ZoneOffset.UTC))//
-				.setUpdateTime(user.getUpdateTime().toEpochSecond(ZoneOffset.UTC))//
-				.build();
+        return response.getExist();
+    }
 
-		CreateUserResponse response = userServiceBlockingStub.createUser(request);
+    @Override
+    public boolean createUser(User user) {
+        benchmark.rpc.grpc.UserServiceOuterClass.User request = benchmark.rpc.grpc.UserServiceOuterClass.User
+                .newBuilder()//
+                .setId(user.getId())//
+                .setName(user.getName())//
+                .setSex(user.getSex())//
+                .setBirthday((int) (user.getBirthday().toEpochDay()))//
+                .setEmail(user.getEmail())//
+                .setMobile(user.getMobile())//
+                .setAddress(user.getAddress())//
+                .setIcon(user.getIcon())//
+                .addAllPermissions(user.getPermissions())//
+                .setStatus(user.getStatus())//
+                .setCreateTime(user.getCreateTime().toEpochSecond(ZoneOffset.UTC))//
+                .setUpdateTime(user.getUpdateTime().toEpochSecond(ZoneOffset.UTC))//
+                .build();
 
-		return response.getSuccess();
-	}
+        CreateUserResponse response = null;
+        try {
+            response = userServiceFutureStub().createUser(request).get();
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
 
-	@Override
-	public User getUser(long id) {
-		GetUserRequest request = GetUserRequest.newBuilder().setId(id).build();
-		benchmark.rpc.grpc.UserServiceOuterClass.User response = userServiceBlockingStub.getUser(request);
+        return response.getSuccess();
+    }
 
-		User user = new User();
-		user.setId(response.getId());
-		user.setName(response.getName());
-		user.setSex(response.getSex());
-		user.setBirthday(LocalDate.ofEpochDay(response.getBirthday()));
-		user.setEmail(response.getEmail());
-		user.setMobile(response.getMobile());
-		user.setAddress(response.getAddress());
-		user.setIcon(response.getIcon());
-		user.setPermissions(response.getPermissionsList());
-		user.setStatus(response.getStatus());
-		user.setCreateTime(LocalDateTime.ofEpochSecond(response.getCreateTime(), 0, ZoneOffset.UTC));
-		user.setUpdateTime(LocalDateTime.ofEpochSecond(response.getUpdateTime(), 0, ZoneOffset.UTC));
+    @Override
+    public User getUser(long id) {
+        GetUserRequest request = GetUserRequest.newBuilder().setId(id).build();
+        UserServiceOuterClass.User response = null;
+        try {
+            response = userServiceFutureStub().getUser(request).get();
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
 
-		return user;
-	}
+        User user = new User();
+        user.setId(response.getId());
+        user.setName(response.getName());
+        user.setSex(response.getSex());
+        user.setBirthday(LocalDate.ofEpochDay(response.getBirthday()));
+        user.setEmail(response.getEmail());
+        user.setMobile(response.getMobile());
+        user.setAddress(response.getAddress());
+        user.setIcon(response.getIcon());
+        user.setPermissions(response.getPermissionsList());
+        user.setStatus(response.getStatus());
+        user.setCreateTime(LocalDateTime.ofEpochSecond(response.getCreateTime(), 0, ZoneOffset.UTC));
+        user.setUpdateTime(LocalDateTime.ofEpochSecond(response.getUpdateTime(), 0, ZoneOffset.UTC));
 
-	@Override
-	public Page<User> listUser(int pageNo) {
-		ListUserRequest request = ListUserRequest.newBuilder().setPageNo(pageNo).build();
-		UserPage response = userServiceBlockingStub.listUser(request);
+        return user;
+    }
 
-		Page<User> page = new Page<>();
+    @Override
+    public Page<User> listUser(int pageNo) {
+        ListUserRequest request = ListUserRequest.newBuilder().setPageNo(pageNo).build();
+        UserPage response = null;
+        try {
+            response = userServiceFutureStub().listUser(request).get();
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
 
-		page.setPageNo(response.getPageNo());
-		page.setTotal(response.getTotal());
+        Page<User> page = new Page<>();
 
-		List<User> userList = new ArrayList<>(response.getResultCount());
+        page.setPageNo(response.getPageNo());
+        page.setTotal(response.getTotal());
 
-		for (benchmark.rpc.grpc.UserServiceOuterClass.User u : response.getResultList()) {
-			User user = new User();
-			user.setId(u.getId());
-			user.setName(u.getName());
-			user.setSex(u.getSex());
-			user.setBirthday(LocalDate.ofEpochDay(u.getBirthday()));
-			user.setEmail(u.getEmail());
-			user.setMobile(u.getMobile());
-			user.setAddress(u.getAddress());
-			user.setIcon(u.getIcon());
-			user.setPermissions(u.getPermissionsList());
-			user.setStatus(u.getStatus());
-			user.setCreateTime(LocalDateTime.ofEpochSecond(u.getCreateTime(), 0, ZoneOffset.UTC));
-			user.setUpdateTime(LocalDateTime.ofEpochSecond(u.getUpdateTime(), 0, ZoneOffset.UTC));
+        List<User> userList = new ArrayList<>(response.getResultCount());
 
-			userList.add(user);
-		}
+        for (benchmark.rpc.grpc.UserServiceOuterClass.User u : response.getResultList()) {
+            User user = new User();
+            user.setId(u.getId());
+            user.setName(u.getName());
+            user.setSex(u.getSex());
+            user.setBirthday(LocalDate.ofEpochDay(u.getBirthday()));
+            user.setEmail(u.getEmail());
+            user.setMobile(u.getMobile());
+            user.setAddress(u.getAddress());
+            user.setIcon(u.getIcon());
+            user.setPermissions(u.getPermissionsList());
+            user.setStatus(u.getStatus());
+            user.setCreateTime(LocalDateTime.ofEpochSecond(u.getCreateTime(), 0, ZoneOffset.UTC));
+            user.setUpdateTime(LocalDateTime.ofEpochSecond(u.getUpdateTime(), 0, ZoneOffset.UTC));
 
-		page.setResult(userList);
+            userList.add(user);
+        }
 
-		return page;
-	}
+        page.setResult(userList);
+
+        return page;
+    }
 
 }

--- a/grpc-server/src/main/java/benchmark/rpc/Server.java
+++ b/grpc-server/src/main/java/benchmark/rpc/Server.java
@@ -12,6 +12,7 @@ public class Server {
 		ServerBuilder//
 				.forPort(port)//
 				.addService(new UserServiceGrpcServerImpl())//
+				.directExecutor()
 				.build()//
 				.start()//
 				.awaitTermination();


### PR DESCRIPTION
主要更新客户端的调用代码和配置。原来的代码服务端的cpu占用不到10%
结果是原来的三倍(同样机器以上。服务端cpu使用率在50%左右
服务端用的aws的c5.2xlarge， 同样的8vcpu
性能的瓶颈明显在客户端（但这不能说明是rpc框架客户端的性能）
客户端用的是c5.4xlarge，16vcpu

> 生成时间: 2019-08-05T03:10:13.561277<br>
> 运行环境: Linux, OpenJDK 64-Bit Server VM 11.0.4+11-post-Ubuntu-1ubuntu218.04.3<br>
> 启动参数: java -server -Xmx1g -Xms1g -XX:MaxDirectMemorySize=1g -XX:+UseG1GC<br>


## existUser
| framework | thrpt (ops/ms) | avgt (ms) | p90 (ms) | p99 (ms) | p999 (ms) |
|:--- |:---:|:---:|:---:|:---:|:---:|
|grpc|161.214|0.198|0.311|0.55|0.852|


## createUser
| framework | thrpt (ops/ms) | avgt (ms) | p90 (ms) | p99 (ms) | p999 (ms) |
|:--- |:---:|:---:|:---:|:---:|:---:|
|grpc|157.001|0.212|0.276|0.398|1.239|


## getUser
| framework | thrpt (ops/ms) | avgt (ms) | p90 (ms) | p99 (ms) | p999 (ms) |
|:--- |:---:|:---:|:---:|:---:|:---:|
|grpc|148.302|0.21|0.309|0.485|0.912|


## listUser
| framework | thrpt (ops/ms) | avgt (ms) | p90 (ms) | p99 (ms) | p999 (ms) |
|:--- |:---:|:---:|:---:|:---:|:---:|
|grpc|92.414|0.345|0.605|0.974|1.982|